### PR TITLE
Update CSS to support sticky PR sidebar

### DIFF
--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -1,11 +1,19 @@
-.header {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 100;
+/* Offset the start of the body by the height of the navbar */
+body {
+  padding-top: 49px;
 }
 
-body {
-    padding-top: 49px;
+/* Give the heade a fixed width at the top */
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+
+/* Offset the sticky PR sidebar */
+.discussion-sidebar {
+  padding-top: 49px;
+  margin-top: -49px;
 }


### PR DESCRIPTION
The GitHub Team has made the sidebar for pull-requests sticky, but if
you used the extension, it would hide behind the navbar.
